### PR TITLE
README - Update path to stylestats defaults

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ grunt.initConfig({
 
 ### Options
 
-The options are exactly the same as in the [stylestats library](https://github.com/t32k/stylestats/blob/master/lib/defaultOptions.js). Those are the defaults:
+The options are exactly the same as in the [stylestats library](https://github.com/t32k/stylestats/blob/master/assets/default.json). Those are the defaults:
 
 ```json
 {


### PR DESCRIPTION
404 being returned by current path, updated to reference default.json in assets directory.
